### PR TITLE
python 3.7 support (resolves #35)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,16 @@ addons:
 matrix:
   include:
     - { python: "3.6", env: TOXENV=flake8 }
+    - { python: "3.7", dist: xenial, sudo: required, env: DJANGO=2.0 }
+    - { python: "3.7", dist: xenial, sudo: required, env: DJANGO=master }
 
   exclude:
     - { python: "2.7", env: DJANGO=master }
     - { python: "2.7", env: DJANGO=2.0 }
     - { python: "3.4", env: DJANGO=master }
     - { python: "3.6", env: DJANGO=1.10 }
+    - { python: "3.7", env: DJANGO=1.10 }
+    - { python: "3.7", env: DJANGO=1.11 }
 
   allow_failures:
     - env: DJANGO=master

--- a/regex_field/fields.py
+++ b/regex_field/fields.py
@@ -5,6 +5,9 @@ from django.db.models import Model
 from django.db.models.fields import CharField
 
 
+_PATTER_TYPE = type(re.compile(''))
+
+
 class CastOnAssignDescriptor(object):
     """
     A property descriptor which ensures that `field.to_python()` is called on _every_ assignment to the field.
@@ -93,7 +96,7 @@ class RegexField(CharField):
             obj = self.value_from_object(obj)
 
         # Check for re type before accessing pattern
-        if isinstance(obj, re._pattern_type):
+        if isinstance(obj, _PATTER_TYPE):
             return obj.pattern
 
         # Return None by default

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist =
     flake8
     py{27,34,35}-django110
     py{27,34,35,36}-django111
-    py{34,35,36}-django20
-    py{35,36}-djangomaster
+    py{34,35,36,37}-django20
+    py{35,36,37}-djangomaster
 
 [testenv]
 setenv =


### PR DESCRIPTION
Python 3.7 support on travis is kinda wonky https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905

Setting `dist: xenial, sudo: required` globally would break at very least python 3.4 tests. I guess it will be acceptable after 3.4 reaches EoL in 2019-03-16 (https://devguide.python.org/#branchstatus), but for now it seems better to keep that option to python 3.7 enough.