### PR TITLE
setting an or because the value cannot exist and it doesnt mean that …

### DIFF
--- a/regex_field/fields.py
+++ b/regex_field/fields.py
@@ -75,7 +75,7 @@ class RegexField(CharField):
         if isinstance(value, type(re.compile(''))):
             return value
         else:
-            if value is None and self.null:
+            if value is None or self.null:
                 return None
             else:
                 try:


### PR DESCRIPTION
…the field is Null